### PR TITLE
匿名类转换bug修正

### DIFF
--- a/Kogel.Dapper.Extension/Extension/AnonymousExtension.cs
+++ b/Kogel.Dapper.Extension/Extension/AnonymousExtension.cs
@@ -76,8 +76,16 @@ namespace Kogel.Dapper.Extension.Extension
                         {
                             var item = properties[i];
                             var value = reader[item.Name];
+
+                            Type nullableType = Nullable.GetUnderlyingType(item.PropertyType);
+
                             if (value != DBNull.Value)
-                                value = Convert.ChangeType(value, item.PropertyType);
+                            {
+                                if (nullableType != null)
+                                    value = Convert.ChangeType(value, nullableType);
+                                else
+                                    value = Convert.ChangeType(value, item.PropertyType);
+                            }
                             else
                                 value = default;
                             array[i] = value;


### PR DESCRIPTION
如果实体内含有可空类型，如（int? a），那么在查询后使用 Get(x=>new{x.a}) 生成匿名类时，将会发生转换错误。此提交修正此错误